### PR TITLE
Added webservice-functions to mod_grouptool

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -103,4 +103,58 @@ $functions = [
         'type'        => 'write',
         'ajax'        => true,
         ],
+
+        'mod_grouptool_get_grouptools_by_courses' => [
+        'classname'     => 'mod_grouptool_external',
+        'methodname'    => 'get_grouptools_by_courses',
+        'classpath'     => 'mod/grouptool/externallib.php',
+        'description'   => 'Get all grouptools for the given courses',
+        'type'          => 'write',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+        'mod_grouptool_get_grouptool' => [
+        'classname'     => 'mod_grouptool_external',
+        'methodname'    => 'get_grouptool',
+        'classpath'     => 'mod/grouptool/externallib.php',
+        'description'   => 'Get the grouptool with the given id',
+        'type'          => 'write',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+        'mod_grouptool_register' => [
+        'classname'     => 'mod_grouptool_external',
+        'methodname'    => 'register',
+        'classpath'     => 'mod/grouptool/externallib.php',
+        'description'   => 'Register for group',
+        'type'          => 'write',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+        'mod_grouptool_deregister' => [
+        'classname'     => 'mod_grouptool_external',
+        'methodname'    => 'deregister',
+        'classpath'     => 'mod/grouptool/externallib.php',
+        'description'   => 'deregister for group',
+        'type'          => 'write',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+        'mod_grouptool_change_group' => [
+        'classname'     => 'mod_grouptool_external',
+        'methodname'    => 'change_group',
+        'classpath'     => 'mod/grouptool/externallib.php',
+        'description'   => 'Change from one group to another',
+        'type'          => 'write',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
+
+        'mod_grouptool_get_registration_status' => [
+        'classname'     => 'mod_grouptool_external',
+        'methodname'    => 'get_registration_status',
+        'classpath'     => 'mod/grouptool/externallib.php',
+        'description'   => 'Get the status of the current registration for this user in the given group tool',
+        'type'          => 'read',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+        ],
 ];

--- a/locallib.php
+++ b/locallib.php
@@ -2989,7 +2989,7 @@ class mod_grouptool {
      * @throws dml_exception
      * @throws required_capability_exception
      */
-    protected function unregister_from_agrp($agrpid, $userid=0, $previewonly=false, $force=false) {
+    public function unregister_from_agrp($agrpid, $userid=0, $previewonly=false, $force=false) { // TODO protected -> public
         global $USER, $DB;
 
         if (empty($userid)) {
@@ -3135,7 +3135,7 @@ class mod_grouptool {
      * @throws dml_exception
      * @throws required_capability_exception
      */
-    protected function register_in_agrp($agrpid, $userid=0, $previewonly=false) {
+    public function register_in_agrp($agrpid, $userid=0, $previewonly=false) { // TODO changed from protected to public
         global $USER, $DB;
 
         if (empty($userid)) {
@@ -3377,7 +3377,7 @@ class mod_grouptool {
      * @throws dml_exception
      * @throws required_capability_exception
      */
-    protected function change_group($agrpid, $userid = null, $message = null, $oldagrpid = null) {
+    public function change_group($agrpid, $userid = null, $message = null, $oldagrpid = null) {
         global $DB, $USER;
 
         if ($userid === null) {
@@ -8465,5 +8465,32 @@ class mod_grouptool {
 
     }
 
+    /**
+     * @return object the course module
+     */
+    public function get_course_module() {
+        return $this->cm;
+    }
+
+    /**
+     * @return object the course
+     */
+    public function get_course() {
+        return $this->course;
+    }
+
+    /**
+     * @return object the grouptool
+     */
+    public function get_grouptool() {
+        return $this->grouptool;
+    }
+
+    /**
+     * @return object the context
+     */
+    public function get_context() {
+        return $this->context;
+    }
 }
 

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -1,0 +1,151 @@
+<?php
+
+use mod_grouptool\local\tests\base;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/webservice/tests/helpers.php');
+require_once($CFG->dirroot . '/mod/grouptool/externallib.php');
+
+/**
+ * External mod grouptool functions unit tests
+ */
+class mod_grouptool_external_testcase extends externallib_advanced_testcase {
+    
+    /**
+     * Test if the user only gets grouptool for enrolled courses
+     */
+    public function test_get_grouptools_by_courses() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course1 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse1',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course1->id);
+
+        $course2 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse2',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course2->id);
+
+        $course3 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse3',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $grouptool1 = self::getDataGenerator()->create_module('grouptool', [
+            'course' => $course1->id,
+            'name' => 'Grouptool Module 1',
+            'intro' => 'Grouptool module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $grouptool2 = self::getDataGenerator()->create_module('grouptool', [
+            'course' => $course2->id,
+            'name' => 'Grouptool Module 2',
+            'intro' => 'Grouptool module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $grouptool3 = self::getDataGenerator()->create_module('grouptool', [
+            'course' => $course3->id,
+            'name' => 'Grouptool Module 3',
+            'intro' => 'Grouptool module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_grouptool_external::get_grouptools_by_courses([]);
+
+        // user is enrolled only in course1 and course2, so the third grouptool module in course3 should not be included
+        $this->assertEquals(2, count($result->grouptools));
+    }
+
+
+    /**
+     * Test if the user gets a valid grouptool from the endpoint
+     */
+    public function test_get_grouptool() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $grouptool = self::getDataGenerator()->create_module('grouptool', [
+            'course' => $course->id,
+            'name' => 'Grouptool Module',
+            'intro' => 'Grouptool module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_grouptool_external::get_grouptool($grouptool->id);
+
+        // grouptool name should be equal to 'Grouptool Module'
+        $this->assertEquals('Grouptool Module', $result->grouptool->name);
+
+        // Course id in grouptool should be equal to the id of the course
+        $this->assertEquals($course->id, $result->grouptool->course);
+    }
+
+
+    /**
+     * Test if the user gets an exception when the grouptool is hidden in the course
+     */
+    public function test_get_grouptool_hidden() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $grouptool = self::getDataGenerator()->create_module('grouptool', [
+            'course' => $course->id,
+            'name' => 'Hidden Grouptool Module',
+            'intro' => 'Grouptool module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+            'visible' => 0,
+        ]);
+
+        $this->setUser($user);
+
+        // Test should throw require_login_exception
+        $this->expectException(require_login_exception::class);
+
+        $result = mod_grouptool_external::get_grouptool($grouptool->id);
+
+    }
+
+}


### PR DESCRIPTION
The grouptool can only be interacted with using a browser. This PR
solves this problem by providing moodle webservice endpoints.
Currently only student-relevant endpoints are available as this is our
goal. However, the webservices can be extended easily.

To provide webservice functions for the mod_grouptool plugin the
following additions were made:

- Added db/services.php which includes the description of the 6
  endpoints
- Added tests/externallib_test.php which includes unit tests for the
  endpoints
- Added tests/generator/lib.php which includes the
  testing_module_generator for unit tests
- Added externallib.php which includes the actual endpoints.

Following endpoints were added:

- mod_grouptool_get_grouptools_by_courses
- mod_grouptool_get_grouptool
- mod_grouptool_register
- mod_grouptool_deregister
- mod_grouptool_change_group
- mod_grouptool_get_registration_status

_The collection of PRs posted by us, providing webservice functions, is supposed to serve the use-case of providing a student API for TUWEL (TU Wien Moodle Platform). It is with that purpose in mind, that we chose the plugins and the functionality to provide via web service. The following PRs are related to this effort:_
- [Checkmark](https://github.com/academic-moodle-cooperation/moodle-mod_checkmark/pull/65)
- [Grouptool](https://github.com/academic-moodle-cooperation/moodle-mod_grouptool/pull/23)
- [Offline-Quiz](https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/pull/151)
- [Organizer](https://github.com/academic-moodle-cooperation/moodle-mod_organizer/pull/97)
- [Publication](https://github.com/academic-moodle-cooperation/moodle-mod_publication/pull/51)