### PR TITLE
Fix "Queue places per user" and "Queue places per group" defaults not being applied when creating a new activity

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -380,15 +380,11 @@ class mod_grouptool_mod_form extends moodleform_mod {
      * @param array $defaultvalues passed by reference
      */
     public function data_preprocessing(&$defaultvalues) {
-        if (array_key_exists('users_queues_limit', $defaultvalues) && ($defaultvalues['users_queues_limit'] > 0)) {
-            $defaultvalues['limit_users_queues'] = 1;
-        } else {
-            $defaultvalues['limit_users_queues'] = 0;
+        if (array_key_exists('users_queues_limit', $defaultvalues)) {
+            $defaultvalues['limit_users_queues'] = $defaultvalues['users_queues_limit'] > 0 ? 1 : 0;
         }
-        if (array_key_exists('groups_queues_limit', $defaultvalues) && ($defaultvalues['groups_queues_limit'] > 0)) {
-            $defaultvalues['limit_groups_queues'] = 1;
-        } else {
-            $defaultvalues['limit_groups_queues'] = 0;
+        if (array_key_exists('groups_queues_limit', $defaultvalues)) {
+            $defaultvalues['limit_groups_queues'] = $defaultvalues['groups_queues_limit'] > 0 ? 1 : 0;
         }
 
         parent::data_preprocessing($defaultvalues);


### PR DESCRIPTION
In Site administration > Plugins > Grouptool > Default instance settings, I have both of these filled in with non-zero values (1 and 5, respectively).

However, when I go to Add an activity or resource > Grouptool, the "limit" checkboxes next to both of these fields are unticked. Despite that, the correct values are displayed in the disabled input fields:

![image](https://github.com/academic-moodle-cooperation/moodle-mod_grouptool/assets/127017591/12442dc4-ec3c-41c4-8116-a02dccb46089)

I tracked the cause down to `mod_grouptool_mod_form::data_preprocessing()`. At first glance, this code looks like it should tick both boxes:

```php
        if (array_key_exists('users_queues_limit', $defaultvalues) && ($defaultvalues['users_queues_limit'] > 0)) {
            $defaultvalues['limit_users_queues'] = 1;
        } else {
            $defaultvalues['limit_users_queues'] = 0;
        }
        if (array_key_exists('groups_queues_limit', $defaultvalues) && ($defaultvalues['groups_queues_limit'] > 0)) {
            $defaultvalues['limit_groups_queues'] = 1;
        } else {
            $defaultvalues['limit_groups_queues'] = 0;
        }
```

However, it doesn't work for newly created activities because `$defaultvalues` only contains a subset of the fields at this point, not all of the defaults set in the admin area, so it is always set to `0` for new activities. I have changed it to this:

```php
        if (array_key_exists('users_queues_limit', $defaultvalues)) {
            $defaultvalues['limit_users_queues'] = $defaultvalues['users_queues_limit'] > 0 ? 1 : 0;
        }
        if (array_key_exists('groups_queues_limit', $defaultvalues)) {
            $defaultvalues['limit_groups_queues'] = $defaultvalues['groups_queues_limit'] > 0 ? 1 : 0;
        }
```

So it only overrides the defaults set in `mod_grouptool_mod_form::definition()` when a different value is provided - i.e. when editing an existing activity.