### PR TITLE
Shift registration start/end dates when resetting a course and changing the start date

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -889,6 +889,11 @@ function grouptool_reset_userdata($data) {
     $componentstr = get_string('modulenameplural', 'grouptool');
     $status = [];
 
+    if ($data->timeshift) {
+        shift_course_mod_dates('grouptool', ['timeavailable', 'timedue'], $data->timeshift, $data->courseid);
+        $status[] = array('component' => $componentstr, 'item' => get_string('datechanged'), 'error' => false);
+    }
+
     $grouptoolids = $DB->get_fieldset_select('grouptool', 'id', 'course = ?',
                                               [$data->courseid]);
 

--- a/lib.php
+++ b/lib.php
@@ -891,7 +891,7 @@ function grouptool_reset_userdata($data) {
 
     if ($data->timeshift) {
         shift_course_mod_dates('grouptool', ['timeavailable', 'timedue'], $data->timeshift, $data->courseid);
-        $status[] = array('component' => $componentstr, 'item' => get_string('datechanged'), 'error' => false);
+        $status[] = ['component' => $componentstr, 'item' => get_string('date'), 'error' => false];
     }
 
     $grouptoolids = $DB->get_fieldset_select('grouptool', 'id', 'course = ?',


### PR DESCRIPTION
This matches built-in modules such as 'assign'.